### PR TITLE
feat: 카카오앱 없을때 웹 로그인

### DIFF
--- a/android/app/src/main/kotlin/com/team/visioneer/prayu/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/team/visioneer/prayu/MainActivity.kt
@@ -34,17 +34,18 @@ class MainActivity : FlutterActivity() {
     }
 
     private fun startSchemeIntent(url: String): Boolean {
-        return try {
-            // 'intent://'로 시작하는 URL을 처리
-            val schemeIntent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME)
+    return try {
+        // 'intent://'로 시작하는 URL을 처리
+        val schemeIntent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME)
 
-            // 앱이 설치되어 있으면 해당 앱으로 이동
-            startActivity(schemeIntent)
-            true
-        } catch (e: URISyntaxException) {
-            Log.e("MainActivity", "URI Syntax Error: $e")
-            false
-        } catch (e: ActivityNotFoundException) {
+        // 앱이 설치되어 있으면 해당 앱으로 이동
+        startActivity(schemeIntent)
+        true
+    } catch (e: URISyntaxException) {
+        Log.e("MainActivity", "URI Syntax Error: $e")
+        false
+    } catch (e: ActivityNotFoundException) {
+        if (!url.startsWith("intent:#")) {
             // 앱이 설치되어 있지 않은 경우 Play 스토어로 이동
             try {
                 val storeIntent = Intent(
@@ -55,7 +56,10 @@ class MainActivity : FlutterActivity() {
             } catch (ex: ActivityNotFoundException) {
                 Log.e("MainActivity", "Play Store not found: $ex")
             }
-            false
+        } else {
+            Log.i("MainActivity", "URL starts with #, skipping Play Store redirect.")
         }
+        false
     }
+}
 }


### PR DESCRIPTION
카카오톡이 없을 때 웹에서 로그인이 되도록 설정합니다!

로그인할 때는 intent:# 을 사용하고
그 외 - 카카오 공유, 카카오 문의는 intent://을 사용하고 있어서 

로그인할 때 (intent:#일 때) 만 앱이 없으면 직접 그 페이지로 이동시키도록 하였습니다!!

https://www.notion.so/mmyeong/feat-4695b6cf8c444a2b8f24304f5cb7d11b?pvs=4